### PR TITLE
fix: type instability causing performance issue.

### DIFF
--- a/src/BEM.jl
+++ b/src/BEM.jl
@@ -24,10 +24,10 @@ function gradient_greens end
 function integral end
 function integral_gradient end
 
-∑ = sum
-τ̅ = 2π
+const ∑ = sum
+const τ̅ = 2π
 #τ = 2.0unit_π
-PointNonDim = AbstractVector{<:Real}
+const PointNonDim = AbstractVector{<:Real}
 
 include("Meshes.jl") #capytaine one
 include("green_functions/rankine.jl")


### PR DESCRIPTION
Before:
```
Rankine
  4.301 μs (199 allocations: 5.03 KiB)
  8.036 μs (286 allocations: 12.64 KiB)
  13.157 μs (486 allocations: 17.70 KiB)
```

After:
```
Rankine
  1.415 μs (50 allocations: 2.67 KiB)
  3.453 μs (112 allocations: 7.50 KiB)
  4.887 μs (162 allocations: 10.17 KiB)
```