### PR TITLE
refactor: Green function that can be fast with SVector or Zygote-differentiable with Vectors

### DIFF
--- a/src/BEM.jl
+++ b/src/BEM.jl
@@ -24,10 +24,7 @@ function gradient_greens end
 function integral end
 function integral_gradient end
 
-∑ = sum
-τ̅ = 2π
-#τ = 2.0unit_π
-PointNonDim = AbstractVector{<:Real}
+const τ̅ = 2π
 
 include("Meshes.jl") #capytaine one
 include("green_functions/rankine.jl")

--- a/src/green_functions/exact_Guevel_Delhommeau.jl
+++ b/src/green_functions/exact_Guevel_Delhommeau.jl
@@ -57,22 +57,30 @@ function gradient_greens(::ExactGuevelDelhommeau, element_1, element_2, wavenumb
     xi = element_2.center
     r  = wavenumber * hypot(x[1] - xi[1], x[2] - xi[2])
     z  = wavenumber * (x[3] + xi[3])
+    dGF_dr = _d_dimless_wave_term_dr(r, z)
+    dGF_dz = _d_dimless_wave_term_dz(r, z)
     if with_respect_to_first_variable
         if abs(r) > 1e-6
-            dr_dx = wavenumber^2 / r * [x[1] - xi[1], x[2] - xi[2]]
+            dr_dx1 = wavenumber^2 / r * (x[1] - xi[1])
+            dr_dx2 = wavenumber^2 / r * (x[2] - xi[2])
         else
-            dr_dx = [0.0, 0.0]
+            dr_dx1 = zero(x[1])
+            dr_dx2 = zero(x[2])
         end
         dz_dx = wavenumber
-        return wavenumber * [dr_dx * _d_dimless_wave_term_dr(r, z); dz_dx * _d_dimless_wave_term_dz(r, z)]
+        return wavenumber * (zero(x) .+ (dr_dx1 * dGF_dr, dr_dx2 * dGF_dr, dz_dx * dGF_dz))
+        # The zero(x) is a workaround to convert the following tuple to the same type as `x` (either Vector or SVector).
     else
         if abs(r) > 1e-6
-            dr_dxi = wavenumber^2 / r * [xi[1] - x[1], xi[2] - x[2]]
+            dr_dxi1 = wavenumber^2 / r * (xi[1] - x[1])
+            dr_dxi2 = wavenumber^2 / r * (xi[2] - x[2])
         else
-            dr_dxi = [0.0, 0.0]
+            dr_dxi1 = zero(x[1])
+            dr_dxi2 = zero(x[2])
         end
         dz_dxi = wavenumber
-        return wavenumber * [dr_dxi * _d_dimless_wave_term_dr(r, z); dz_dxi * _d_dimless_wave_term_dz(r, z)]
+        return wavenumber * (zero(x) .+ (dr_dxi1 * dGF_dr, dr_dxi2 * dGF_dr, dz_dxi * dGF_dz))
+        # The zero(x) is a workaround to convert the following tuple to the same type as `x` (either Vector or SVector).
     end
 end
 

--- a/src/green_functions/rankine.jl
+++ b/src/green_functions/rankine.jl
@@ -1,43 +1,16 @@
 struct Rankine <: GreensFunction end
 
-_distance(x̅::PointNonDim, ξ̅::PointNonDim) = √∑((x̅ .- ξ̅) .^ 2)
+_distance(x, ξ) = norm(x .- ξ)
 
 # All functions below depends on wavenumber but the variable is actually unused.
 # It is just part of the signature to have the same signature than the wave part of the Green function.
 
 function greens(::Rankine, element_1, element_2, wavenumber=nothing)
-    """
-        greens(::Rankine, element_1, element_2, wavenumber=nothing)
-
-    Calculates the Green's function between two panels on a floating body.
-
-    # Arguments
-    - `element_1`: first panel .
-    - `element_2`: second panel.
-    - `wavenumber`: The wavenumber (optional, default is `nothing`). If provided, this parameter defines the wavenumber for waves.
-    # Returns
-    - The Rankine Green's function value between the two specified panels, which represents the influence of one panel on the other.
-    """
     r = _distance(element_1[:center], element_2[:center])
     return 1 / r
 end
 
 function gradient_greens(::Rankine, element_1, element_2, wavenumber=nothing; with_respect_to_first_variable=false)
-    """
-    gradient_greens(::Rankine, element_1, element_2, wavenumber=nothing; with_respect_to_first_variable=false)
-
-    Calculates the gradient of the Rankine Green's function between two panels on a floating body, integrating the influence of one panel on the other.
-
-    # Arguments
-    - `element_1`: First panel.
-    - `element_2`: Second panel.
-    - `wavenumber`: The wavenumber (optional, default is `nothing`). Defines the wavenumber for waves ~~~~~
-    - `with_respect_to_first_variable`: A boolean flag (default is `false`). If `true`, computes the gradient with respect to `element_1`; otherwise, computes the gradient with respect to `element_2`.
-
-    # Returns
-    - The gradient of the Rankine Green's function, representing the influence of one panel on the other, integrated over the panels, with respect to the panel. This is different for direct and indirect BEM
-"""
-
     r = _distance(element_1[:center], element_2[:center])
     r̅ = element_2[:center] - element_1[:center]
     ∇ₓ = 1/r^3*r̅
@@ -49,121 +22,98 @@ function gradient_greens(::Rankine, element_1, element_2, wavenumber=nothing; wi
 end
 
 function integral(::Rankine, element_1, element_2, wavenumber=nothing)
-    @views begin
     point = element_1[:center]
     source_point = element_2[:center]
     source_vertices = element_2[:vertices]
     source_radius = element_2[:radius]
     source_normal = element_2[:normal]
     source_area = element_2[:area]
-    end
-    r = _distance(point, source_point)
+    r̄ = point - source_point
+    r = norm(r̄)
     if r > 7 * source_radius # if far -> Rankine Direct
-        function_integral = source_area / r
+        integral = source_area / r
     else  # else (if close) deal with singularity
-        function_integral = zero(source_area)
-        r̄ = point - source_point
+        integral = 0.0
         GZ = dot(r̄, source_normal)
-        RR = @inbounds [_distance(point, source_vertices[i,:]) for i in 1:4]
-        NEXT_NODE = [2, 3, 4, 1]
-        @views begin
-        for L in 1:4
-            DK = _distance(source_vertices[NEXT_NODE[L],:], source_vertices[L,:])
-            if DK >= 1e-3 * source_radius
-                PJ = (source_vertices[NEXT_NODE[L],:] - source_vertices[L,:]) / DK
-                # The following GYX are called (a,b,c) in [Del]
-                GYX = cross(source_normal, PJ)
-                GY = dot(point - source_vertices[L,:], GYX)
-                ANT = 2 * GY * DK
-                DNT = (RR[NEXT_NODE[L]] + RR[L])^2 - DK^2 +
-                    2 * abs(GZ) * (RR[NEXT_NODE[L]] + RR[L])
-                ANL = RR[NEXT_NODE[L]] + RR[L] + DK
-                DNL = RR[NEXT_NODE[L]] + RR[L] - DK
+        RR = ntuple(i -> _distance(point, source_vertices[i,:]), 4)
+        for index_vertex in 1:4
+            current_vertex = source_vertices[index_vertex, :]
+            index_next_vertex = mod1(index_vertex+1, 4)
+            next_vertex = source_vertices[index_next_vertex, :]
+            current_to_next = next_vertex - current_vertex
+            segment_length = norm(current_to_next)
+            if segment_length >= 1e-3 * source_radius
+                GY = dot(point - current_vertex, cross(source_normal, current_to_next / segment_length))
+                if abs(GZ) >= 1e-4 * source_radius
+                    ANT = 2 * GY * segment_length
+                    DNT = (RR[index_next_vertex] + RR[index_vertex])^2 - segment_length^2 +
+                            2 * abs(GZ) * (RR[index_next_vertex] + RR[index_vertex])
+                    integral -= 2*abs(GZ) * atan(ANT, DNT)
+                end
+                if abs(GY) > 1e-5
+                    ANL = RR[index_next_vertex] + RR[index_vertex] + segment_length
+                    DNL = RR[index_next_vertex] + RR[index_vertex] - segment_length
+                    ALDEN = log(ANL / DNL)
+                    integral += GY * ALDEN
+                end
+            end
+        end
+    end
+    return integral
+end
+
+function integral_gradient(::Rankine, element_1, element_2, wavenumber=nothing; with_respect_to_first_variable=false)
+    point = element_1[:center]
+    source_point = element_2[:center]
+    source_vertices = element_2[:vertices]
+    source_normal = element_2[:normal]
+    source_radius = element_2[:radius]
+    source_area = element_2[:area]
+    r̄ = point - source_point
+    r = norm(r̄)
+    if r > 7 * source_radius # if far -> Rankine Direct
+        derivative = 1 / r^3 * r̄
+        integral_gradient = derivative * source_area
+    else  # else (if close) deal with singularity
+        integral_gradient = zero(point)
+        GZ = dot(r̄, source_normal)
+        RR = ntuple(i -> _distance(point, source_vertices[i,:]), 4)
+        DRX = ntuple(i -> (point - source_vertices[i,:]) / RR[i], 4)
+        for index_vertex in 1:4
+            current_vertex = source_vertices[index_vertex,:]
+            index_next_vertex = mod1(index_vertex+1, 4)
+            next_vertex = source_vertices[index_next_vertex, :]
+            current_to_next = next_vertex - current_vertex
+            segment_length = norm(current_to_next)
+            if segment_length >= 1e-3 * source_radius
+                GYX = cross(source_normal, current_to_next / segment_length)
+                GY = dot(point - current_vertex, GYX)
+                ANT = 2 * GY * segment_length
+                DNT = (RR[index_next_vertex] + RR[index_vertex])^2 - segment_length^2 +
+                    2 * abs(GZ) * (RR[index_next_vertex] + RR[index_vertex])
+                ANL = RR[index_next_vertex] + RR[index_vertex] + segment_length
+                DNL = RR[index_next_vertex] + RR[index_vertex] - segment_length
                 ALDEN = log(ANL / DNL)
                 if abs(GZ) >= 1e-4 * source_radius
                     AT = atan(ANT, DNT)  #check difference
                 else
-                    AT = zero(ANT) # zero of type 
+                    AT = 0.0
                 end
-                if abs(GY) < 1e-5 # edge case
-                    function_integral -= 2 * AT * abs(GZ)
-                else
-                    function_integral += GY * ALDEN - 2 * AT * abs(GZ)
-                end
+                #error bound error in the line below...
+                ANLX = DRX[index_next_vertex] + DRX[index_vertex]
+                ANTX = 2 * segment_length * GYX
+                DNTX = 2 * (RR[index_next_vertex] + RR[index_vertex] + abs(GZ)) * ANLX +
+                    2 * sign(GZ) * (RR[index_next_vertex] + RR[index_vertex]) * source_normal
+                integral_gradient = integral_gradient .-
+                                        (ALDEN .* GYX .- 2 * sign(GZ) * AT .* source_normal .+
+                                        GY * (DNL - ANL) ./ (ANL .* DNL) .* ANLX .-
+                                        2 * abs(GZ) .* (ANTX .* DNT .- DNTX .* ANT) ./ (ANT .* ANT .+ DNT .* DNT))
             end
         end
     end
-end
-    return function_integral
-end
-
-
-function integral_gradient(::Rankine, element_1, element_2, wavenumber=nothing; with_respect_to_first_variable=false)
-    @views begin
-    point = element_1[:center]
-    source_point = element_2[:center]
-    source_vertices = element_2[:vertices]
-    source_normal = element_2[:normal]
-    source_radius = element_2[:radius]
-    source_area = element_2[:area]
-        end
-    r = _distance(point, source_point)
-    r̅ =  point - source_point
-    if r > 7 * source_radius # if far -> Rankine Direct
-        derivative = 1 / r^3 * r̅
-        derivative_integral = derivative * source_area
-    else  # else (if close) deal with singularity
-        r̄ = point - source_point
-        GZ = dot(r̄, source_normal)
-        RR = @inbounds [_distance(point, source_vertices[i, :]) for i in 1:4]
-        DRX = @inbounds [(point - source_vertices[i, :]) / RR[i] for i in 1:4]
-        
-        VS_contribs = @inbounds [
-            begin
-                next_node = L % 4 + 1
-                DK = _distance(source_vertices[next_node, :], source_vertices[L, :])
-        
-                if DK >= 1e-3 * source_radius
-                    PJ = (source_vertices[next_node, :] - source_vertices[L, :]) / DK
-        
-                    # The following GYX are called (a, b, c) in [Del]
-                    GYX = cross(source_normal, PJ)
-                    GY = dot(point - source_vertices[L, :], GYX)
-        
-                    ANT = 2 * GY * DK
-                    DNT = (RR[next_node] + RR[L])^2 - DK^2 +
-                        2 * abs(GZ) * (RR[next_node] + RR[L])
-                    ANL = RR[next_node] + RR[L] + DK
-                    DNL = RR[next_node] + RR[L] - DK
-                    ALDEN = log(ANL / DNL)
-        
-                    if abs(GZ) >= 1e-4 * source_radius
-                        AT = atan(ANT, DNT)
-                    else
-                        AT = zero(ANT)
-                    end
-        
-                    ANLX = DRX[next_node] + DRX[L]
-                    ANTX = 2 * DK * GYX
-                    DNTX = 2 * (RR[next_node] + RR[L] + abs(GZ)) * ANLX +
-                        2 * sign(GZ) * (RR[next_node] + RR[L]) * source_normal
-        
-                    ALDEN .* GYX .- 2 * sign(GZ) * AT .* source_normal .+
-                        GY * (DNL - ANL) ./ (ANL .* DNL) .* ANLX .-
-                        2 * abs(GZ) .* (ANTX .* DNT .- DNTX .* ANT) ./ (ANT .* ANT .+ DNT .* DNT)
-                else
-                    zeros(typeof(source_area), 3)  # No contribution
-                end
-            end
-            for L in 1:4
-        ]
-            # Aggregate contributions without mutation
-            derivative_integral = -sum(VS_contribs)
-            end
-
-        if with_respect_to_first_variable
-            return -derivative_integral
-        else
-            return derivative_integral
-        end
+    if with_respect_to_first_variable
+        return -integral_gradient
+    else  # Gradient with respect to second variable
+        return integral_gradient
     end
+end

--- a/src/green_functions/wu_.jl
+++ b/src/green_functions/wu_.jl
@@ -31,20 +31,26 @@ function gradient_greens(::GFWu, element_1, element_2, wavenumber; with_respect_
     dGF_dvv = -GF_Func_L0(vv, dd, alpha, beta, rho) - GF_Func_W(hh, vv) + 2/dd
     if with_respect_to_first_variable
         if abs(hh) > 1e-6
-            dhh_dx = wavenumber^2 / hh * [x[1] - xi[1], x[2] - xi[2]]
+            dhh_dx1 = wavenumber^2 / hh * (x[1] - xi[1])
+            dhh_dx2 = wavenumber^2 / hh * (x[2] - xi[2])
         else
-            dhh_dx = [zero(hh), zero(hh)]
+            dhh_dx1 = zero(x[1])
+            dhh_dx2 = zero(x[2])
         end
         dvv_dx = wavenumber
-        return wavenumber * [dhh_dx * dGF_dhh; dvv_dx * dGF_dvv]
+        return wavenumber * (zero(x) .+ (dhh_dx1 * dGF_dhh, dhh_dx2 * dGF_dhh, dvv_dx * dGF_dvv))
+        # The zero(x) is a workaround to convert the following tuple to the same type as `x` (either Vector or SVector).
     else
         if abs(hh) > 1e-6
-            dhh_dxi = wavenumber^2 / hh * [xi[1] - x[1], xi[2] - x[2]]
+            dhh_dxi1 = wavenumber^2 / hh * (xi[1] - x[1])
+            dhh_dxi2 = wavenumber^2 / hh * (xi[2] - x[2])
         else
-            dhh_dxi = [zero(hh), zero(hh)]
+            dhh_dxi1 = zero(x[1])
+            dhh_dxi2 = zero(x[2])
         end
         dvv_dxi = wavenumber
-        return wavenumber * [dhh_dxi * dGF_dhh; dvv_dxi * dGF_dvv]
+        return wavenumber * (zero(x) .+ (dhh_dxi1 * dGF_dhh, dhh_dxi2 * dGF_dhh, dvv_dxi * dGF_dvv))
+        # The zero(x) is a workaround to convert the following tuple to the same type as `x` (either Vector or SVector).
     end
 end
 


### PR DESCRIPTION
Replaces #1.

If the `element`s are built with SVectors, the evaluation is state-of-the-art fast.
If they are Vectors, it is a bit slower, but the code is Zygote-differentiable.

Performance of some of the gradients with Zygote seems slightly worse than before. I'm not sure how to really interpret that.

```
WITH STATIC VECTORS

Evaluation
 Rankine
  140.250 ns (0 allocations: 0 bytes)
  162.703 ns (0 allocations: 0 bytes)
 GFWu
  68.591 ns (0 allocations: 0 bytes)
  106.808 ns (0 allocations: 0 bytes)

WITH VECTORS

Evaluation
 Rankine
  1.313 μs (33 allocations: 2.58 KiB)
  2.415 μs (70 allocations: 5.47 KiB)
 GFWu
  70.861 ns (0 allocations: 0 bytes)
  222.322 ns (4 allocations: 416 bytes)

Gradients
 Rankine
  661.467 μs (2696 allocations: 81.56 KiB)
  5.365 ms (14671 allocations: 436.78 KiB)
 GFWu
  48.893 μs (424 allocations: 19.31 KiB)
  525.291 μs (2598 allocations: 84.78 KiB)
```

<details><summary>Benchmark code</summary>
<p>

```julia
using BEM
using BenchmarkTools
using StaticArrays
using Zygote

wavenumber = 1.0

println("WITH STATIC VECTORS")
element_1 = (center=SVector(0.0, 0.0, -1.0),)
element_2 = (
    center=SVector(1.0, 1.0, -2.0),
    vertices= @SMatrix([-0.5 -0.5 0.0; 0.5 -0.5 0.0; 0.5 0.5 0.0; -0.5 0.5 0.0]) .+ SVector(1.0, 1.0, -2.0)',
    normal=SVector(0.0, 0.0, 1.0),
    radius=sqrt(2)/2,
    area=1.0,
)

println("Evaluation")
println(" Rankine")
@btime BEM.integral($(Rankine()), $element_1, $element_2)
@btime BEM.integral_gradient($(Rankine()), $element_1, $element_2)

println(" GFWu")
@btime BEM.integral($(GFWu()), $element_1, $element_2, $wavenumber)
@btime BEM.integral_gradient($(GFWu()), $element_1, $element_2, $wavenumber)

println("WITH VECTORS")
element_1 = (center=[0.0, 0.0, -1.0],)
element_2 = (
    center=[1.0, 1.0, -2.0],
    vertices= [-0.5 -0.5 0.0; 0.5 -0.5 0.0; 0.5 0.5 0.0; -0.5 0.5 0.0] .+ [1.0, 1.0, -2.0]',
    normal=[0.0, 0.0, 1.0],
    radius=sqrt(2)/2,
    area=1.0,
)

println("Evaluation")
println(" Rankine")
@btime BEM.integral($(Rankine()), $element_1, $element_2)
@btime BEM.integral_gradient($(Rankine()), $element_1, $element_2)

println(" GFWu")
@btime BEM.integral($(GFWu()), $element_1, $element_2, $wavenumber)
@btime BEM.integral_gradient($(GFWu()), $element_1, $element_2, $wavenumber)

println("Gradients")
println(" Rankine")
S(z) = BEM.integral(Rankine(), (center=[0.0, 0.0, z],), element_2)
@btime Zygote.gradient($S, $(-1.0))
D(z) = BEM.integral_gradient(Rankine(), (center=[0.0, 0.0, z],), element_2)
@btime Zygote.jacobian($D, $(-1.0))

println(" GFWu")
S(z) = real(BEM.integral(GFWu(), (center=[0.0, 0.0, z],), element_2, wavenumber))
@btime Zygote.gradient($S, $(-1.0))
D(z) = real.(BEM.integral_gradient(GFWu(), (center=[0.0, 0.0, z],), element_2, wavenumber))
@btime Zygote.jacobian($D, $(-1.0))

nothing

```

</p>
</details> 